### PR TITLE
Snakesim improvements

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,5 +14,7 @@ RUN groupadd -o -g $GID $USER && \
     useradd -om -u $UID -g $GID -G sudo -s /bin/bash $USER && \
     echo "$USER:$PW" | chpasswd
 
+RUN echo '\nsource /ros_entrypoint.sh' >> home/$USER/.bashrc
+
 USER $USER
 WORKDIR /home/$USER

--- a/snakesim/src/snakesim/renderer.py
+++ b/snakesim/src/snakesim/renderer.py
@@ -30,6 +30,7 @@ License:
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
+from threading import Thread
 import numpy as np
 import pygame
 
@@ -53,6 +54,7 @@ class Renderer(object):
         window_size = int(scaling * (bounds + 2*padding))
         pygame.display.init()
         self._screen = pygame.display.set_mode((window_size, window_size))
+        self._thread = None
 
     def _convert_to_display_coords(self, position):
         """Convert game coordinates to display coordinates."""
@@ -64,6 +66,11 @@ class Renderer(object):
 
     def render(self, goal, snake):
         """Render the current state of the game."""
+
+        if self._thread is not None and self._thread.is_alive():
+            # Still rendering the last frame, drop this one
+            return
+
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 pygame.quit()
@@ -94,4 +101,5 @@ class Renderer(object):
             int(snake.head.radius*self.scaling)
         )
 
-        pygame.display.flip()
+        self._thread = Thread(target=pygame.display.flip)
+        self._thread.start()


### PR DESCRIPTION
This adds two minor unrelated improvements.

## multithreaded rendering
Previously `pygame.display.flip()` ran in the main thread. This is a blocking call that normally doesn't take much time and therefore doesn't present an issue. However, when X forwarding a display (such as when using WSL2), this function takes a significant amount of time to run. On my machine, it slowed the entire logic loop down from 30 Hz to 20 Hz. Using `cProfile`, I confirmed that this call was the problem.

Running it in a disposable thread partially resolves this issue. The displayed frame rate is inconsistent (this is an issue with X forwarding on WSL2), but the logic loop rate is now stable.

To test, run `rostopic hz /snake/pose` while on WSL2 using X forwarding. You will see it is a stable 30 Hz with the fix. You will likely see it run lower without the fix, but this may depend on hardware capability.

## ROS environment sourcing
When using `docker-join.sh`, the `ros_entrypoint.sh` isn't sourced. This is fixed by adding it to the bashrc.

To test, run `roscore` in a terminal created by joining a running container. You will see it doesn't fail. Without the fix, it will fail.

