### PR TITLE
checkout docs folder from documentation branch

### DIFF
--- a/docs/00_introduction.md
+++ b/docs/00_introduction.md
@@ -1,0 +1,97 @@
+# Introduction
+This set of documents will guide you through setting up your computer with the
+ARC development environment. This environment is created and run through Docker,
+which is a lightweight virtual machine. It has very little overhead and greatly
+simplifies the set up process for new users.
+
+At the end of this guide, you will have the environment set up on your machine
+and ready for use.
+
+## Development Environment Explanation
+The ARC development environment is an Ubuntu 18.04 instance with ROS Melodic
+installed. It has a few other tools installed as well. You will access it
+primarily through a shell (command line) interface, but you can also use an IDE
+like Visual Studio Code to develop as if everything was installed on your
+machine directly.
+
+### ROS
+ROS stands for Robot Operating System. It is an industry standard tool for
+creating autonomous robots. Essentially, it is a framework to create a mesh of
+nodes that work together to control your robot. It has an API for both C++
+and Python. Through it, you have a common language to define messages that
+are sent from one node to another (for example a path planning node can send
+waypoint messages to a low level control node). The beauty of it is that all the
+nodes can be modular and developed independently if you have a well defined
+interface of messages.
+
+Another really excellent reason to use ROS is the 2000+ number of existing
+packages that can act as 'plug and play' into your existing network. If you have
+a new sensor you're looking to try, someone has probably already written a ROS
+driver for it. Tasks such as mapping, perception, and state estimation that many
+robots need to do probably have multiple packages that you can experiment with
+and pick the best one for your specific application. There are also pre-defined
+messages for standard things like sensor data and control commands. For these
+reasons it can be really useful for jump-starting a new project.
+
+Through this club, you will be learning much more about ROS. The `snake_tutorial`
+package will walk you through creating a few simple nodes that can be chained
+together to control a snake to reach a goal. You will also have the opportunity
+to expand on the very basic controller given to you in an open ended challenge
+to create the highest performing AI for the snake.
+
+A downside of ROS is that it works really well on Ubuntu, but isn't well
+supported on other operating systems. This is why we must set up a very specific
+development environment for the club.
+
+For more information on ROS, check out their wiki: <http://wiki.ros.org/ROS/Introduction>
+
+## Operating System
+See the below instructions depending on what operating system you are running.
+
+### Windows
+This guide was mainly written for students using Windows 10. Historically, this
+has been the dominant OS for our members, and it was also difficult to get
+started on. Read and follow all set up documents in order. You will first 
+install and configure WSL2, then set up Docker, then build and test the ARC
+development environment.
+
+Versions of Windows other than Windows 10 do not appear to be supported by
+Docker, so therefore the ARC development environment is not supported on them.
+You will need to upgrade to WIndows 10, dual boot, or run a Linux VM. That is
+outside the scope of this document.
+
+### Mac
+Presently, this guide has not been tested on a Mac system. In theory it should
+work fine because there is a version of Docker for Mac. You can skip directly
+over the WSL2 guide (since it is Windows specific) and continue with Docker
+setup. You will then build and test the ARC development environment.
+
+### Linux
+This guide has been tested to work on Ubuntu 18.04. If you have a different
+distribution, it should also work without issue, provided there is a Docker
+release for you. If you run Linux as a dual boot with one of the above operating
+systems, it may be worth installing the ARC development environment in both. See
+the notes on dual booting below. For setting up the environment, you can skip
+directly over the WSL2 guide (since it is Windows specific) and continue with
+Docker setup. You will then build and test the ARC development environment.
+
+## Dual Boot Considerations
+For the best possible experience, it may be worth looking into setting up a dual
+boot. ROS was designed to run on Ubuntu, so running it natively without anything
+extra in the way will give you the least hassle when actually trying to run
+code. Setting up the dual boot can be quite a hassle for an inexperienced user,
+which is why we recomend using WSL2 / Docker. This also saves you from needing
+to restart your computer every time you want to switch modes.
+
+Setting up a dual boot is outside the scope of this guide, but you should be
+able to find plenty of resources online. You will want to install the version of
+Ubuntu that is correct for the version of ROS you are intending to use. This
+information can be found the [ROS wiki](http://wiki.ros.org/ROS/Installation)
+Presently, the club is using ROS Melodic, which is designed to run on Ubuntu
+18.04. You will then need to decide if you are running ROS natively or though
+Docker. That is also outside the scope of this document.
+
+You can also install a different version of Ubuntu for your dual boot, then use
+Docker in order to run the version you need. This will likely give you better
+performance than running Docker on Windows or Mac, and you can follow the Linux
+set up steps noted above.

--- a/docs/01_wsl2.md
+++ b/docs/01_wsl2.md
@@ -1,0 +1,127 @@
+# WSL2
+WSL2 stands for Windows Subsystem for Linux verison 2. Essentially, Windows is
+running a full Linux system in tandem with Windows. This has much better
+performance than running a virtual machine (VM) or using the original WSL.
+
+This document will guide you through setting up WSL 2 on Windows 10.
+
+## Installing WSL 2
+Microsoft has published an [online guide](https://docs.microsoft.com/en-us/windows/wsl/install-win10),
+for setting up WSL2, but a more detailed, step-by-step guide is included below.
+Follow the steps below, but you may refer to the online guide if you get stuck.
+
+Check and update your Windows version:
+   1. WSL2 Requires you are running at least Windows 10, version 2004, Build 19041 or higher. 
+   2. To check your Windows version: Type “About your PC” in Windows search and click it or press enter
+   3. Scroll down to “Windows Specification” and check “Version”. If you are 2004 or above, move on to step 2
+   4. If you are below Version 2004, you will have to update Windows. The easiest way is to search “Windows update settings” in window search. Click it or press enter
+   5. If there is a prompt to update to 2004 or above, please follow the instruction and then proceed to step 2. If Windows says the update is “on it’s way” or similar, follow the remaining instructions
+   6. Go to the following link https://www.microsoft.com/en-us/software-download/windows10 and select “update now” towards the top. This will download an update assistant tool which will allow you to update to version 2004 or above.
+   7. Run the program and follow it’s instructions. After completing the update, verify you are on version 2004 or above by following previous steps.
+
+Enable WSL:
+   1. Search for and click “Turn Windows features on or off” in windows search.
+   2. Check the “Windows Subsystem for Linux” option
+   3. Click “OK”
+   4. Restart Computer
+
+Download Ubuntu:
+   1. Go to the Microsoft Store by searching for “Microsoft Store” in windows search. Click it or hit enter.
+   2. In the Microsoft Store, search for and install “Ubuntu 18.04 LTS”
+
+Verify version:
+   1. In a Windows Terminal, run “wsl -l -v”
+   2. If this command failed, you likely have WSL installed instead of WSL2, or you may not have installed Ubuntu correctly. If it shows “Ubuntu” with Version “2” you are good to go.
+
+
+## Setting up X forwarding
+X forwarding is what will let you display GUIs (graphical user interfaces)
+on your Windows machine that are being run from your WSL2 instance. You need
+to install an X client, set up the appropriate firewall rules, then tell WSL2
+to forward it's display to your client.
+
+The following steps will show you how to set this up. For more information,
+check out this [StackOverflow post](https://stackoverflow.com/questions/61110603/how-to-set-up-working-x11-forwarding-on-wsl2).
+
+### X Client Set Up
+There are several options available here. VcXsrv has been tested to work with
+the ARC development environment and is available on [SourceForge](https://sourceforge.net/projects/vcxsrv/).
+VcXsrv is the recommended client.
+
+[Xming](http://www.straightrunning.com/XmingNotes/) is also popular, but more
+recent versions of the software are blocked behind a paywall. You can download
+the latest free versions on [SourceForge](http://www.straightrunning.com/XmingNotes/).
+
+When you launch your X client for the first time, you will see several
+configuration pages.
+1. Leave the display settings at the default: multiple windows, -1
+2. Leave the client settings at the default: start no clients
+3. Modify the extra settings as follows:
+   - Check "Disable access control". This is safe to do, since we will use
+     Windows Firewall to block the client. This allows your WSL2 and Docker
+     instances to access the client.
+
+### Windows Firewall Setup
+When you first launch your X client, you should see Windows Firwall pop up. Go
+ahead and tell it to block the program on atleast public networks.
+
+Now that everything is blocked, we need to put in an exception so that our WSL2
+instance is able to access the X client.
+
+1. Hit the Windows key and type "Firewall" then hit enter.
+2. Navigate to "Inbound Rules"
+3. Scroll until you find "VcXsrv windows xserver. There should be four enabled, blocking rules.
+4. Select the only rule that is both "Profile: Public" and "Protocol: TCP"
+5. Select "Copy" in the right hand window
+6. Select "Paste in the right hand window
+7. Select "Disable Rule" in the right hand window
+   - This leaves the original rule as a back up if you ever need to revert your
+     settings for any reason.
+8. Select "Refresh" in the right hand window
+9. Find the new rule. It will be the only rule that is "Enabled: Yes", "Profile: Public", and "Protocol: TCP"
+10. Select "Properties" in the right hand window
+11. Under "General", append " WSL" to the name
+12. Under "General", toggle "Action" from "Block" to "Allow"
+13. Under "Protocols and Ports", change "Local Port" from "All Ports" to "6000".
+14. Under "Scope", change "Remote IP Address" from "Any IP Address" to "These IP addresses:"
+15. Add the following IP address: `172.16.0.0/12`.
+
+Go ahead and save and close everything. You may need to reboot your X client.
+
+### WSL2 Setup
+We will need to edit a file called the `bashrc`. This is a script that is run
+every time you open a new terminal in order to set up your environment. Modify
+it by copy and pasting the below command in _exactly_.
+```bash
+echo -e '\nexport DISPLAY=$(awk '\''/nameserver / {print $2; exit}'\'' /etc/resolv.conf 2>/dev/null):0\nexport LIBGL_ALWAYS_INDIRECT=1' >> ~./bashrc
+```
+Since we just changed our `bashrc`, we need to run the below command for the
+changes to take effect in our current terminal:
+```bash
+source ~/.bashrc
+```
+
+### Testing
+You will need to download a small program called `xeyes` in order to test the X
+forwarding. It can be installed and run with the following commands:
+```bash
+sudo apt install -y x11-apps
+xeyes
+```
+You'll see a little pair of eyes follow your cursor around. You can X out of it
+or hit `CTRL+C` in order to kill the program.
+
+## Installing Microsoft Terminal
+For a much nicer terminal experience, you will want to install the [Windows
+Terminal](https://aka.ms/terminal). Once it is installed, launch it, then click
+the downwards arrow icon on the list of tabs. Select Ubuntu 18.04 from the
+dropdown, and you will be greeted with a bash terminal for your WSL2 instance.
+
+If you'd like to make the default behavior to open WSL2 tabs, you can hit the
+dropdown and select settings. This will prompt you to open a json file. You can
+edit this an any text editor. On line 8, you can paste in the GUID for your WSL2
+instance. This hexadecimal string is found by searching the file for `Ubuntu-18.04`
+then looking two lines up at the GUID entry.
+
+## VS Code Setup
+TODO

--- a/docs/02_docker.md
+++ b/docs/02_docker.md
@@ -1,0 +1,30 @@
+# Docker
+Docker is a lightweight virtual machine (VM) that will let you run the ARC
+development environment with very little overhead. Docker is useful because of
+how lightweight it is, and how these VM instances can be created
+programatically. You will learn more about how to use Docker when setting up the
+ARC development environment.
+
+This document will guide you through setting up Docker on your machine.
+See the below section depending on what OS you are using.
+
+## Windows
+Follow the [installation guide](https://docs.docker.com/docker-for-windows/install-windows-home/)
+to set up Docker to use the WSL2 backend.
+
+The ARC development environment is currently untested on Windows 10 Pro. There 
+are alternate [installation instructions](https://docs.docker.com/docker-for-windows/install/)
+provided, and it seems you will have the option to use the WSL2 backend. For the
+sake of having a uniform configuration for the club, use the WSL2 backend. There
+are [additional notes](https://docs.docker.com/docker-for-windows/wsl/) that may
+be useful.
+
+## Mac
+The ARC development environment is completely untested on Mac, but it should
+work. Follow the [installation guide](https://docs.docker.com/docker-for-mac/install/).
+
+## Linux
+The ARC development environment has been tested on Ubuntu 18.04. Other supported
+distributions should work too. Follow the [installation guide](https://docs.docker.com/engine/install/ubuntu/)
+for your distribution. In the case of Ubuntu, installing via the repository is
+the preferred method of installation.

--- a/docs/03_arc-dev-env.md
+++ b/docs/03_arc-dev-env.md
@@ -1,0 +1,142 @@
+# ARC Development Environment
+The ARC development environment is hosted in a Docker image. This means that it
+is programatically built using a 'Dockerfile' and can be launched with very
+little overhead as a Docker container.
+
+This document will walk you through building the image, and running it as a
+container.
+
+## Building the Image
+To build the image, you need to give step-by-step commands to Docker. This is
+typically done through the use of a 'Dockerfile.' You will therefore need the
+Dockerfile associated with the ARC development environment. If you have not
+already clone this repository to your computer, do so now.
+
+### Cloning the repository
+If using Windows, you should clone the repository to the WSL2 filesystem. The
+easiest way to do that is to simply use the WSL2 terminal while running the
+following commands.
+
+The convenience scripts provided assume that you will be using this environment
+in the context of a catkin workspace. You will need to do that to run the
+`snake_tutorial` later on. No need to worry about what that means exactly, but
+for now, make the following directory structure before cloning the repo.
+```bash
+cd
+mkdir -p arc_ws/src
+cd arc_ws/src
+git clone https://github.com/purdue-arc/arc_tutorials.git
+```
+Note that you may modify the first command if you would like the workspace in a
+directory other than your home folder. The rest of the tutorial will assume it
+is in your home folder when giving absolute `cd` commands, so modify those if
+you choose a different directory.
+
+If you recieve an error that git is not installed, you can install it with the
+following command on Ubuntu (our WSL2 instance is Ubuntu):
+```bash
+sudo apt install -y git
+```
+
+Back to building the image.
+
+Navigate to the `docker` directory and run the `docker-build.sh` script.
+```bash
+cd arc_tutorials/docker
+./docker-build.sh
+```
+This script may take some time to run. Behind the scenes, it is telling Docker
+to build a new image based off of our Dockerfile. Our Dockerfile is telling
+Docker to pull an existing Ubuntu ROS image off of [DockerHub](https://hub.docker.com/r/osrf/ros/),
+install updates, install some helpful tools, and set up a new user.
+
+You will see a note about changing the password after it finishes. It should be
+fine to leave the sudo password as is, but you can change it if you want. To
+commit your changes, see the section below.
+
+Let's check that the image is actually built properly:
+```bash
+docker image ls
+```
+
+That command tells Docker to list all the images on your machine. If you see one
+named `arc-dev`, then it worked.
+
+## Running as a Container
+Now that the image is built, we can run it.
+
+Again, there is a convenience script to make sure you pass all the appropriate
+arguments to Docker.
+```bash
+./docker-run.sh
+```
+
+This script will run the `arc-dev` image, pass in arguments in order to forward
+the X display server, make the catkin workspace a shared folder between the
+host and the container, and name the container `arc-dev`. It will also run it
+in foreground and temporary mode. This means your current terminal will now run
+commands in the container, not on your host. When this original connection is
+closed (exiting the window, CTRL+D, or `exit`), the container will stop and all
+data will be lost. Data written to the shared folder will persist since it is
+actually pointing to your host. Data written to anyehwere else (such as
+installed programs) will be lost unless if you commit your changes.
+
+To test that everything is working, let's try running ROS.
+```bash
+roscore
+```
+
+You will see some messages about starting a new ROS master, then you can kill
+the process with `CTRL+C`. We didn't install ROS on your host machine, so the
+fact that it ran there means the development environment is properly set up.
+
+## Committing changes
+Commiting changes allows you to save the current state of your running
+container to the image (or a new image). This can be useful if are doing some
+rapid iteration and testing and need to install a few extra files. Or if you
+want to modify something outside of the shared directory like your `bashrc` or
+password.
+
+If these are more persistant changes that other users (like teammates
+on your project) will want to have, a better solution is to create a project
+specific Dockerfile. This is outside the scope of this document.
+
+The command is `docker commit`  
+You run it like so:
+```bash
+docker commit <container name> <image name>:<tag>
+```
+
+For example, to take the current container and overwrite the existing image:
+```bash
+docker commit arc-dev arc-dev
+```
+If no tag is specified, `:latest` is assumed.
+
+You can use tags in order to save specific states or version of an image. That
+is outside the scope of this document.
+
+## Joining the Container in a New Terminal
+Many times, you will want to have multiple terminals open in a container so that
+you can run multiple programs at once. There is a convenience script you can use
+in order to to this.
+
+From the host, run the script:
+```bash
+./docker-join.sh
+```
+
+You can use `roscore` to verify everything is set up properly. Remember that
+closing the _original_ terminal will end the container even if you have several
+other terminals joined.
+
+## Testing X Forwarding
+X forwarding is how the display from the container is sent to your host. In the
+Dockerfile, a small program called `xeyes` was installed. You can run it inside
+the container to make sure your display works.
+```bash
+xeyes
+```
+
+You'll see a little pair of eyes follow your cursor around. You can X out of it
+or hit `CTRL+C` in order to kill the program.

--- a/docs/04_next-steps.md
+++ b/docs/04_next-steps.md
@@ -1,0 +1,4 @@
+# Next Steps
+Congratulations, you've successfully gotten the ARC development environment up
+and running. You are now ready to move on to the `snake_tutorial`. Take a look
+at the `snake_tutorial/docs` folder to get started.


### PR DESCRIPTION
We should try to have a working version of this merged in tonight so that we can give them links to the WSL2 page. I pulled over just the `docs` folder from documentation. In the future, I think the merge of the whole `documentation` branch will work out OK with auto merge ...